### PR TITLE
travis: use custom FQDN for GitHub pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,7 @@ deploy:
   repo: EGI-Foundation/EGI-Foundation.github.io
   # Target branch
   target_branch: master
+  # Custom FQDN for GitHub pages
+  fqdn: docs.egi.eu
   on:
     branch: master

--- a/static/.github/PULL_REQUEST_TEMPLATE.md
+++ b/static/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+> This project is only used to host the generated documentation and is not
+> meant to receive Pull Requests.
+
+> In case you would like to open an issue or Pull Request please do it in the
+> following source repository: https://github.com/EGI-Foundation/documentation

--- a/static/README.md
+++ b/static/README.md
@@ -1,0 +1,7 @@
+# EGI Documentation
+
+> This project is only used to host the generated documentation and is not
+> meant to receive Pull Requests.
+
+> In case you would like to open an issue or Pull Request please do it in the
+> following source repository: https://github.com/EGI-Foundation/documentation


### PR DESCRIPTION
travis: use custom FQDN for GitHub pages: https://docs.egi.eu

Before one hour the Let's Encrypt certificate for HTTPS should be setup.