### PR TITLE
config: use lunar.js search instead of non working google search

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -92,13 +92,13 @@ time_format_default = "January 2, 2006"
 rss_sections = ["blog"]
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
-gcs_engine_id = "011217106833237091527:la2vtv2emlw"
+# gcs_engine_id = ""
 
 # Enable Algolia DocSearch
 algolia_docsearch = false
 
 #Enable offline search with Lunr.js
-offlineSearch = false
+offlineSearch = true
 
 # User interface configuration
 [params.ui]


### PR DESCRIPTION
config: use lunar.js search instead of non working google search as documented on https://www.docsy.dev/docs/adding-content/navigation/#configure-local-search-with-lunr.
Fix #46 