### PR TITLE
getting started providers: route to various places

### DIFF
--- a/content/en/providers/getting-started/_index.md
+++ b/content/en/providers/getting-started/_index.md
@@ -5,6 +5,17 @@ type: docs
 weight: 10
 ---
 
-{{% pageinfo %}}
-This is a placeholder page.
-{{% /pageinfo %}}
+The pages under this section depict how to join the EGI infrastructure as
+a service providers offering innovative services to the European Research Area.
+
+> Interested in integrating with Check-in? Head to the
+  [Check-in for service provicers](https://docs.egi.eu/providers/check-in/)!
+
+> Interested in joining the EGI Federated Cloud? Head to the section on
+  [Cloud Compute](https://docs.egi.eu/providers/cloud-compute/)!
+
+> Willing to deploy a Oneprovider? Head to
+  [DataHub](https://docs.egi.eu/providers/datahub/) section!
+  
+> And if you want learn about EGI Notebooks, head to the
+  Notebooks](https://docs.egi.eu/providers/notebooks/) section!

--- a/content/en/providers/getting-started/_index.md
+++ b/content/en/providers/getting-started/_index.md
@@ -8,8 +8,12 @@ weight: 10
 The pages under this section depict how to join the EGI infrastructure as
 a service providers offering innovative services to the European Research Area.
 
-> Interested in integrating with Check-in? Head to the
-  [Check-in for service provicers](https://docs.egi.eu/providers/check-in/)!
+> Interested in integrating your service with Check-in? Head to the
+  [Check-in for service provicers](https://docs.egi.eu/providers/check-in/sp/)!
+  
+> Interested in connecting your Identity Providres and allowing your users to
+  access services via Check-in? Head to the
+  [Check-in for Identity Providers](https://docs.egi.eu/providers/check-in/idp/)!
 
 > Interested in joining the EGI Federated Cloud? Head to the section on
   [Cloud Compute](https://docs.egi.eu/providers/cloud-compute/)!


### PR DESCRIPTION
Some simple text to remove a placeholder.

Wondering if notebooks doc shouldn't go under internal services, is it really something to be deployed by service providers themselves?