### PR TITLE
Check in add header to linking guide

### DIFF
--- a/content/en/users/check-in/linking/_index.md
+++ b/content/en/users/check-in/linking/_index.md
@@ -6,7 +6,7 @@ description: >
   Linking additional organisational/social identities to your EGI Account
 ---
 
-## Linking New Identities to your EGI Account
+## Linking new Identities to your EGI Account
 
 Identity linking allows you to access EGI resources with your existing personal
 EGI ID, using any of the login credentials you have linked to your account. You

--- a/content/en/users/check-in/linking/_index.md
+++ b/content/en/users/check-in/linking/_index.md
@@ -6,6 +6,8 @@ description: >
   Linking additional organisational/social identities to your EGI Account
 ---
 
+## Linking New Identities to your EGI Account
+
 Identity linking allows you to access EGI resources with your existing personal
 EGI ID, using any of the login credentials you have linked to your account. You
 can use any of your organisational or social login credentials for this purpose.

--- a/content/en/users/check-in/linking/_index.md
+++ b/content/en/users/check-in/linking/_index.md
@@ -6,7 +6,7 @@ description: >
   Linking additional organisational/social identities to your EGI Account
 ---
 
-## Linking new Identities to your EGI Account
+## Linking new identities to your EGI Account
 
 Identity linking allows you to access EGI resources with your existing personal
 EGI ID, using any of the login credentials you have linked to your account. You

--- a/content/en/users/check-in/linking/_index.md
+++ b/content/en/users/check-in/linking/_index.md
@@ -28,8 +28,8 @@ To link a new organisational or social identity to your EGI account:
 
    ![Check-in my account](./check-in-my-account.png)
 
-1. Under the **Organisational Identities** section of your profile page,
-   expand **Actions** menu and click **Link New Identity**.
+1. Under the **Organisational Identities** section of your profile page, expand
+   **Actions** menu and click **Link New Identity**.
 
    ![Link new identity](./check-in-link-new.png)
 
@@ -74,8 +74,8 @@ To link a subject DN to your EGI account:
 
    ![Check-in my account](./check-in-my-account.png)
 
-1. Under the **Organisational Identities** section of your profile page,
-   expand **Actions** menu and click **Link New Identity**.
+1. Under the **Organisational Identities** section of your profile page, expand
+   **Actions** menu and click **Link New Identity**.
 
    ![Link new identity](./check-in-link-new.png)
 


### PR DESCRIPTION
# Summary

This PR fixes the missing table of content in the [linking guide](https://docs.egi.eu/users/check-in/linking/).
If there is defined only one header in the body of the guide, then the table of contents is hidden.

Also to maintain the guide clean, there is a commit for fixing the code styling
