### PR TITLE
Hotfix replace edu person entiltements

### DIFF
--- a/content/en/providers/check-in/sp/_index.md
+++ b/content/en/providers/check-in/sp/_index.md
@@ -307,14 +307,13 @@ UserInfo Endpoint:
 
 <!-- markdownlint-disable line-length no-inline-html -->
 
-| Scope                          | Claims                                                                                                                       |
-| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| `openid`                       | `sub`                                                                                                                        |
-| `profile`                      | <ul><li>`name`</li><li>`given_name`</li><li>`family_name`</li><li>`preferred_username`</li></ul>                             |
-| `email`                        | <ul><li>`email`</li><li>`email_verified`</li><li>`voperson_verified_email`</li></ul>                                         |
-| `refeds_edu`                   | <ul><li>`acr`</li><li>`eduperson_assurance`</li><li>`eduperson_scoped_affiliation`</li><li>`eduperson_entitlement`</li></ul> |
-| `eduperson_scoped_affiliation` | `eduperson_scoped_affiliation`                                                                                               |
-| `eduperson_entitlement`        | `eduperson_entitlement`                                                                                                      |
+| Scope                          | Claims                                                                                           |
+| ------------------------------ | ------------------------------------------------------------------------------------------------ |
+| `openid`                       | `sub`                                                                                            |
+| `profile`                      | <ul><li>`name`</li><li>`given_name`</li><li>`family_name`</li><li>`preferred_username`</li></ul> |
+| `email`                        | <ul><li>`email`</li><li>`email_verified`</li><li>`voperson_verified_email`</li></ul>             |
+| `eduperson_scoped_affiliation` | `eduperson_scoped_affiliation`                                                                   |
+| `eduperson_entitlement`        | `eduperson_entitlement`                                                                          |
 
 <!-- markdownlint-enable line-length no-inline-html -->
 

--- a/content/en/providers/check-in/sp/_index.md
+++ b/content/en/providers/check-in/sp/_index.md
@@ -669,10 +669,10 @@ user authorisation:
 
 <!-- markdownlint-disable line-length -->
 
-| Description                                                                                     | OIDC Claim                |
-| ----------------------------------------------------------------------------------------------- | ------------------------- |
-| [VO/group membership/roles of the authenticated user](#vogroup-membership-and-role-information) | `edu_person_entitlements` |
-| [Level of Assurance (LoA)](#level-of-assurance)                                                 | `acr`                     |
+| Description                                                                                     | OIDC Claim              |
+| ----------------------------------------------------------------------------------------------- | ----------------------- |
+| [VO/group membership/roles of the authenticated user](#vogroup-membership-and-role-information) | `eduperson_entitlement` |
+| [Level of Assurance (LoA)](#level-of-assurance)                                                 | `acr`                   |
 
 <!-- markdownlint-enable line-length -->
 
@@ -1098,7 +1098,7 @@ Check-in in order to control user access to resources:
 #### Background
 
 VO/group membership and role information is encoded in entitlements
-(`eduPersonEntitlement` attribute values in SAML or `edu_person_entitlements`
+(`eduPersonEntitlement` attribute values in SAML or `eduperson_entitlement`
 claim in OIDC). These entitlements are typically used to indicate access rights
 to protected resources. Entitlements are multi-valued, with each value formatted
 as a URN.


### PR DESCRIPTION
This PR removes the deprecated scope `refeds_edu` and replaces the old claim name `edu_person_entitlements` with `eduperson_entitlement`